### PR TITLE
docs(dotnet): add initial .NET API documentation and navigation

### DIFF
--- a/docs/dotnet-api/blocks.md
+++ b/docs/dotnet-api/blocks.md
@@ -1,0 +1,193 @@
+---
+title: Blocks
+---
+
+# `Blocks`
+
+`BitcoinKernel.Primatives` and `BitcoinKernel.BlockProcessing`
+
+Block primitives, block-tree access, validation state, and block processing helpers.
+
+---
+
+## Block
+
+```csharp
+public sealed class Block : IDisposable
+{
+    public static Block FromBytes(byte[] rawBlockData);
+
+    public int TransactionCount { get; }
+    public byte[] GetHash();
+    public BlockHeader GetHeader();
+    public byte[] ToBytes();
+    public Transaction? GetTransaction(int index);
+    public IEnumerable<Transaction> GetTransactions();
+
+    public void Dispose();
+}
+```
+
+Represents a full block.
+
+| Method | Description |
+|:-------|:------------|
+| `FromBytes(...)` | Parses a serialized block. |
+| `GetTransaction(int)` | Returns `null` when index is out of range or unavailable. |
+| `GetTransactions()` | Enumerates all available transactions in order. |
+
+---
+
+## BlockHeader
+
+```csharp
+public sealed class BlockHeader : IDisposable
+{
+    public static BlockHeader FromBytes(byte[] rawHeaderData);
+
+    public byte[] GetHash();
+    public byte[] GetPrevHash();
+
+    public uint Timestamp { get; }
+    public uint Bits { get; }
+    public int Version { get; }
+    public uint Nonce { get; }
+
+    public void Dispose();
+}
+```
+
+`FromBytes` requires exactly 80 bytes.
+
+---
+
+## BlockHash
+
+```csharp
+public sealed class BlockHash : IDisposable
+{
+    public static BlockHash FromBytes(byte[] hash);
+    public byte[] ToBytes();
+    public void Dispose();
+}
+```
+
+32-byte hash wrapper.
+
+---
+
+## BlockIndex
+
+```csharp
+public sealed class BlockIndex
+{
+    public int Height { get; }
+    public byte[] GetBlockHash();
+    public BlockIndex? GetPrevious();
+    public BlockHeader GetBlockHeader();
+}
+```
+
+Chain index entry, typically obtained from `Chain` or `ChainstateManager`.
+
+---
+
+## BlockValidationState
+
+```csharp
+public sealed class BlockValidationState : IDisposable
+{
+    public BlockValidationState();
+
+    public ValidationMode ValidationMode { get; }
+    public BitcoinKernel.Interop.Enums.BlockValidationResult ValidationResult { get; }
+
+    public BlockValidationState Copy();
+    public void Dispose();
+}
+```
+
+Validation state object used with `ProcessBlockHeader`.
+
+---
+
+## BlockSpentOutputs
+
+```csharp
+public class BlockSpentOutputs : IDisposable
+{
+    public int Count { get; }
+    public TransactionSpentOutputs GetTransactionSpentOutputs(int transactionIndex);
+    public IEnumerable<TransactionSpentOutputs> EnumerateTransactionSpentOutputs();
+    public void Dispose();
+}
+```
+
+Undo data for a block. Each entry corresponds to a non-coinbase transaction.
+
+---
+
+## BlockProcessor
+
+```csharp
+public sealed class BlockProcessor
+{
+    public BlockProcessor(ChainstateManager chainstateManager);
+
+    public BlockProcessingResult ProcessBlock(Block block);
+    public BlockProcessingResult ProcessBlock(byte[] rawBlockData);
+    public BlockValidationResult ValidateBlock(Block block);
+
+    public Block ReadBlock(BlockTreeEntry blockTreeEntry);
+    public BlockTreeEntry? GetBlockTreeEntry(byte[] blockHash);
+}
+```
+
+High-level helper over `ChainstateManager` for process/read workflows.
+
+---
+
+## BlockProcessingResult
+
+```csharp
+public sealed class BlockProcessingResult
+{
+    public bool Success { get; }
+    public bool IsNewBlock { get; }
+}
+```
+
+Returned by `BlockProcessor.ProcessBlock(...)`.
+
+---
+
+## BlockTreeEntry
+
+```csharp
+public sealed class BlockTreeEntry : IEquatable<BlockTreeEntry>
+{
+    public byte[] GetBlockHash();
+    public BlockTreeEntry? GetPrevious();
+    public int GetHeight();
+}
+```
+
+Block-tree lookup type used by `BlockProcessor`.
+
+---
+
+## BlockValidationResult (wrapper)
+
+```csharp
+public sealed class BlockValidationResult
+{
+    public bool IsValid { get; }
+    public ValidationMode Mode { get; }
+    public int? ErrorCode { get; }
+    public string? ErrorMessage { get; }
+}
+```
+
+Structured validation outcome for `BlockProcessor.ValidateBlock(...)`.
+
+This wrapper type is `BitcoinKernel.BlockProcessing.BlockValidationResult`, and is distinct from enum `BitcoinKernel.Interop.Enums.BlockValidationResult`.

--- a/docs/dotnet-api/chainstate.md
+++ b/docs/dotnet-api/chainstate.md
@@ -1,0 +1,134 @@
+---
+title: Chainstate
+---
+
+# `Chainstate`
+
+`BitcoinKernel.Chain`
+
+Chain selection, chainstate setup, block import, and spent-output reads.
+
+---
+
+## ChainParameters
+
+```csharp
+public sealed class ChainParameters : IDisposable
+{
+    public ChainParameters(ChainType chainType);
+    public void Dispose();
+}
+```
+
+Owns network-specific chain parameters used by `KernelContextOptions`.
+
+---
+
+## ChainstateManagerOptions
+
+```csharp
+public sealed class ChainstateManagerOptions : IDisposable
+{
+    public ChainstateManagerOptions(KernelContext context, string dataDirectory, string blocksDirectory);
+
+    public string DataDirectory { get; }
+    public string BlocksDirectory { get; }
+
+    public ChainstateManagerOptions SetWorkerThreads(int workerThreads);
+    public ChainstateManagerOptions SetWipeDbs(bool wipeBlockTreeDb, bool wipeChainstate);
+    public ChainstateManagerOptions SetBlockTreeDbInMemory(bool inMemory);
+    public ChainstateManagerOptions SetChainstateDbInMemory(bool inMemory);
+    public void Dispose();
+}
+```
+
+Configuration for constructing `ChainstateManager`.
+
+| Method | Description |
+|:-------|:------------|
+| `SetWorkerThreads(int)` | Configure script-check worker threads (0-15). |
+| `SetWipeDbs(bool, bool)` | Wipe block-tree and/or chainstate DB on startup. |
+| `SetBlockTreeDbInMemory(bool)` | Use in-memory block-tree DB. |
+| `SetChainstateDbInMemory(bool)` | Use in-memory chainstate DB. |
+
+---
+
+## ChainstateManager
+
+```csharp
+public sealed class ChainstateManager : IDisposable
+{
+    public ChainstateManager(KernelContext context, ChainParameters chainParams, ChainstateManagerOptions options);
+
+    public Chain GetActiveChain();
+    public BlockIndex GetBestBlockIndex();
+    public bool ProcessBlockHeader(BlockHeader header, out BlockValidationState validationState);
+    public bool ProcessBlock(Block block);
+
+    public bool ImportBlocks(string[] blockFilePaths);
+    public bool ImportBlocks();
+
+    public BlockSpentOutputs ReadSpentOutputs(BlockIndex blockIndex);
+    public void Dispose();
+}
+```
+
+Primary object for chainstate operations.
+
+| Method | Returns | Description |
+|:-------|:--------|:------------|
+| `GetActiveChain()` | `Chain` | Active best chain view. |
+| `GetBestBlockIndex()` | `BlockIndex` | Best entry by cumulative work. |
+| `ProcessBlockHeader(...)` | `bool` | Validates a header and returns copied `BlockValidationState`. |
+| `ProcessBlock(Block)` | `bool` | Validates/connects block, returns whether block was new; throws `ChainstateManagerException` on processing failure. |
+| `ImportBlocks(string[])` | `bool` | Imports block files from explicit paths. |
+| `ImportBlocks()` | `bool` | Imports from configured blocks directory. |
+| `ReadSpentOutputs(BlockIndex)` | `BlockSpentOutputs` | Reads undo/spent outputs for a block. |
+
+---
+
+## Chain
+
+```csharp
+public sealed class Chain
+{
+    public int Height { get; }
+    public BlockIndex GetTip();
+    public BlockIndex? GetBlockByHeight(int height);
+    public BlockIndex GetGenesis();
+    public bool Contains(BlockIndex blockIndex);
+    public IEnumerable<BlockIndex> EnumerateBlocks();
+}
+```
+
+Non-owning view over active chain entries.
+
+| Member | Description |
+|:-------|:------------|
+| `Height` | Current chain tip height. |
+| `GetTip()` | Returns block index at tip height. |
+| `GetBlockByHeight(int)` | Returns entry or `null` if unavailable. |
+| `GetGenesis()` | Returns genesis block index. |
+| `Contains(BlockIndex)` | Membership test for an index in this chain. |
+| `EnumerateBlocks()` | Iterates from height 0 to tip. |
+
+---
+
+## Example
+
+```csharp
+using BitcoinKernel;
+using BitcoinKernel.Chain;
+using BitcoinKernel.Interop.Enums;
+
+using var chainParams = new ChainParameters(ChainType.MAINNET);
+using var contextOptions = new KernelContextOptions().SetChainParams(chainParams);
+using var context = new KernelContext(contextOptions);
+using var options = new ChainstateManagerOptions(context, "/tmp/bitcoin", "/tmp/bitcoin/blocks")
+    .SetWorkerThreads(4);
+using var chainstate = new ChainstateManager(context, chainParams, options);
+
+chainstate.ImportBlocks();
+var chain = chainstate.GetActiveChain();
+Console.WriteLine($"Height: {chain.Height}");
+```

--- a/docs/dotnet-api/context.md
+++ b/docs/dotnet-api/context.md
@@ -1,0 +1,72 @@
+---
+title: Context
+---
+
+# `Context`
+
+`BitcoinKernel.KernelContext` and `BitcoinKernel.KernelContextOptions`
+
+Root context objects used to configure and run kernel operations.
+
+---
+
+## KernelContextOptions
+
+```csharp
+public sealed class KernelContextOptions : IDisposable
+{
+    public KernelContextOptions();
+    public KernelContextOptions SetChainParams(ChainParameters chainParams);
+    public void Dispose();
+}
+```
+
+Builder for context configuration.
+
+| Method | Description |
+|:-------|:------------|
+| `SetChainParams(ChainParameters)` | Sets network/chain parameters for context creation. |
+
+`SetChainParams` returns the same options instance for fluent chaining.
+
+---
+
+## KernelContext
+
+```csharp
+public sealed class KernelContext : IDisposable
+{
+    public KernelContext(KernelContextOptions? options = null);
+    public void Interrupt();
+    public void Dispose();
+}
+```
+
+Main kernel entry-point object.
+
+| Member | Description |
+|:-------|:------------|
+| `KernelContext(...)` | Creates a context using optional options. If omitted, native defaults are used. |
+| `Interrupt()` | Signals long-running operations associated with this context to stop. |
+| `Dispose()` | Releases native context resources. |
+
+---
+
+## Lifecycle Notes
+
+- Keep `KernelContext` alive for the full lifetime of dependent objects (`ChainstateManagerOptions`, `ChainstateManager`).
+- Dispose in reverse construction order.
+
+```csharp
+using BitcoinKernel;
+using BitcoinKernel.Chain;
+using BitcoinKernel.Interop.Enums;
+
+using var chainParams = new ChainParameters(ChainType.SIGNET);
+using var contextOptions = new KernelContextOptions().SetChainParams(chainParams);
+using var context = new KernelContext(contextOptions);
+using var options = new ChainstateManagerOptions(context, "/tmp/bitcoin", "/tmp/bitcoin/blocks");
+using var chainstate = new ChainstateManager(context, chainParams, options);
+
+// ... use chainstate
+```

--- a/docs/dotnet-api/index.md
+++ b/docs/dotnet-api/index.md
@@ -2,25 +2,79 @@
 title: .NET Bindings
 ---
 
-# .NET Bindings — [`dotnet-bitcoinkernel`](https://github.com/janb84/BitcoinKernel.NET) Coming Soon
+# .NET Bindings - [`BitcoinKernel.NET`](https://github.com/janb84/BitcoinKernel.NET)
 
-.NET bindings for `libbitcoinkernel` are not yet available in this documentation.
-
-!!! note "Want to contribute?"
-    If you are familiar with .NET bindings for `libbitcoinkernel`, we would love to include the documentation here. See the [contributor guide](https://github.com/yuvicc/bitcoinkernel-docs/blob/master/README.md) to learn how to add a new language section.
+`BitcoinKernel.NET` provides C# bindings for `libbitcoinkernel` with managed wrappers over native handles.
 
 ---
 
-## What to expect
+## Requirements
 
-.NET bindings will expose the full libbitcoinkernel C API through idiomatic C#, including:
-
-- P/Invoke or `LibraryImport` FFI bindings
-- `IDisposable` resource management
-- Chainstate, block, and transaction access
+| Requirement | Value |
+|:------------|:------|
+| .NET SDK | 9.0+ |
+| Native library | `libbitcoinkernel` (bundled for macOS x64/arm64 in current project state) |
+| Main package | `BitcoinKernel` |
+| Enums package | `BitcoinKernel.Interop.Enums` |
 
 ---
 
-## Tracking
+## Namespace Structure
 
-Follow development in the [Bitcoin Core repository](https://github.com/bitcoin/bitcoin) and community binding projects.
+| Namespace | Description |
+|:----------|:------------|
+| `BitcoinKernel` | Root objects like `KernelContext`, `KernelContextOptions`, `LoggingConnection`. |
+| `BitcoinKernel.Chain` | `Chain`, `ChainParameters`, `ChainstateManager`, `ChainstateManagerOptions`. |
+| `BitcoinKernel.Primatives` | Block/transaction primitives (`Block`, `Transaction`, `TxOut`, `Coin`, etc.). |
+| `BitcoinKernel.ScriptVerification` | `ScriptVerifier` and `PrecomputedTransactionData`. |
+| `BitcoinKernel.BlockProcessing` | `BlockProcessor`, `BlockTreeEntry`, validation result wrappers. |
+| `BitcoinKernel.Exceptions` | Domain-specific exception hierarchy. |
+| `BitcoinKernel.Interop.Enums` | Network, logging, script, and validation enums. |
+
+---
+
+## Memory Management
+
+Most wrapper types own native resources and implement `IDisposable`. Use `using` / `using var` consistently.
+
+```csharp
+using BitcoinKernel;
+using BitcoinKernel.Chain;
+using BitcoinKernel.Interop.Enums;
+
+using var chainParams = new ChainParameters(ChainType.MAINNET);
+using var contextOptions = new KernelContextOptions().SetChainParams(chainParams);
+using var context = new KernelContext(contextOptions);
+using var managerOptions = new ChainstateManagerOptions(
+    context,
+    dataDirectory: "/path/to/datadir",
+    blocksDirectory: "/path/to/blocks");
+using var chainstate = new ChainstateManager(context, chainParams, managerOptions);
+```
+
+Objects returned as non-owning views (for example from `GetOutputAt()` and several chain/block accessors) must not outlive their parent objects.
+
+---
+
+## Quick Start
+
+```csharp
+using BitcoinKernel;
+using BitcoinKernel.Chain;
+using BitcoinKernel.Interop.Enums;
+
+using var logging = new LoggingConnection((category, message, level) =>
+    Console.WriteLine($"[{category}] {message}"));
+
+using var chainParams = new ChainParameters(ChainType.MAINNET);
+using var contextOptions = new KernelContextOptions().SetChainParams(chainParams);
+using var context = new KernelContext(contextOptions);
+using var options = new ChainstateManagerOptions(context, "/tmp/bitcoin", "/tmp/bitcoin/blocks");
+using var chainstate = new ChainstateManager(context, chainParams, options);
+
+chainstate.ImportBlocks();
+
+var chain = chainstate.GetActiveChain();
+Console.WriteLine($"Height: {chain.Height}");
+Console.WriteLine($"Genesis: {Convert.ToHexString(chain.GetGenesis().GetBlockHash())}");
+```

--- a/docs/dotnet-api/kernel-types.md
+++ b/docs/dotnet-api/kernel-types.md
@@ -1,0 +1,199 @@
+---
+title: KernelTypes
+---
+
+# `KernelTypes`
+
+`BitcoinKernel.Interop.Enums` and `BitcoinKernel.Exceptions`
+
+Core enums and exception types used across the .NET bindings.
+
+---
+
+## ChainType
+
+```csharp
+public enum ChainType : uint
+{
+    MAINNET = 0,
+    TESTNET = 1,
+    TESTNET_4 = 2,
+    SIGNET = 3,
+    REGTEST = 4
+}
+```
+
+Selects the Bitcoin network for `ChainParameters`.
+
+---
+
+## ScriptVerificationFlags
+
+```csharp
+[Flags]
+public enum ScriptVerificationFlags : uint
+{
+    None,
+    P2SH,
+    DerSig,
+    NullDummy,
+    CheckLockTimeVerify,
+    CheckSequenceVerify,
+    Witness,
+    Taproot,
+    All,
+    AllPreTaproot
+}
+```
+
+Use these flags with `ScriptVerifier.VerifyScript(...)`.
+
+| Flag | Description |
+|:-----|:------------|
+| `None` | No script checks. |
+| `P2SH` | BIP16 evaluation. |
+| `DerSig` | Strict DER signatures (BIP66). |
+| `NullDummy` | NULLDUMMY checks (BIP147). |
+| `CheckLockTimeVerify` | Enable CLTV (BIP65). |
+| `CheckSequenceVerify` | Enable CSV (BIP112). |
+| `Witness` | SegWit rules (BIP141). |
+| `Taproot` | Taproot/Tapscript rules (BIP341/342). |
+| `All` | Full standard verification set. |
+| `AllPreTaproot` | Full verification without Taproot. |
+
+---
+
+## ScriptVerifyStatus
+
+```csharp
+public enum ScriptVerifyStatus : byte
+{
+    OK,
+    ERROR_INVALID_FLAGS_COMBINATION,
+    ERROR_SPENT_OUTPUTS_REQUIRED,
+    ERROR_TX_INPUT_INDEX,
+    ERROR_SPENT_OUTPUTS_MISMATCH,
+    ERROR_INVALID_FLAGS
+}
+```
+
+Detailed status returned by native script verification.
+
+---
+
+## ValidationMode
+
+```csharp
+public enum ValidationMode : byte
+{
+    VALID = 0,
+    INVALID = 1,
+    INTERNAL_ERROR = 2
+}
+```
+
+Shared status model for block validation outcomes.
+
+---
+
+## BlockValidationResult
+
+```csharp
+public enum BlockValidationResult : uint
+{
+    UNSET,
+    CONSENSUS,
+    CACHED_INVALID,
+    INVALID_HEADER,
+    MUTATED,
+    MISSING_PREV,
+    INVALID_PREV,
+    TIME_FUTURE,
+    HEADER_LOW_WORK
+}
+```
+
+Granular reason for block invalidity.
+
+This enum is `BitcoinKernel.Interop.Enums.BlockValidationResult`, and is distinct from the wrapper class `BitcoinKernel.BlockProcessing.BlockValidationResult` used by `BlockProcessor.ValidateBlock(...)`.
+
+---
+
+## LogLevel
+
+```csharp
+public enum LogLevel : uint
+{
+    TRACE,
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR,
+    FATAL,
+    NONE
+}
+```
+
+---
+
+## LogCategory
+
+```csharp
+public enum LogCategory : byte
+{
+    All,
+    Bench,
+    BlockStorage,
+    CoinDb,
+    LevelDb,
+    Mempool,
+    Prune,
+    Rand,
+    Reindex,
+    Validation,
+    Kernel
+}
+```
+
+---
+
+## Warning
+
+```csharp
+public enum Warning
+{
+    UnknownNewRulesActivated,
+    LargeWorkInvalidChain
+}
+```
+
+---
+
+## Exception Hierarchy
+
+```text
+KernelException
+|- KernelContextException
+|- ScriptVerificationException
+|- BlockValidationException
+|- ChainstateManagerException
+|- LoggingException
+|- ChainParametersException
+|- KernelFatalException
+|- KernelFlushException
+|- TransactionException
+`- BlockException
+```
+
+### ScriptVerificationException
+
+`ScriptVerificationException` exposes a `Status` property of type `ScriptVerifyStatus`.
+
+### BlockValidationException
+
+`BlockValidationException` exposes:
+
+| Property | Type |
+|:---------|:-----|
+| `Result` | `BlockValidationResult` |
+| `Mode` | `ValidationMode` |

--- a/docs/dotnet-api/logger.md
+++ b/docs/dotnet-api/logger.md
@@ -1,0 +1,52 @@
+---
+title: Logger
+---
+
+# `Logger`
+
+`BitcoinKernel.LoggingConnection`
+
+Registers a managed callback for native kernel log output.
+
+---
+
+## LoggingConnection
+
+```csharp
+public sealed class LoggingConnection : IDisposable
+{
+    public LoggingConnection(Action<string, string, int> callback);
+    public void Dispose();
+}
+```
+
+`LoggingConnection` keeps a native logging callback active for its lifetime.
+
+| Callback arg | Meaning |
+|:-------------|:--------|
+| `string category` | Log category name. Current wrapper currently reports default `"kernel"`. |
+| `string message` | Log message text from native code. |
+| `int level` | Log level value. Current wrapper currently reports default `2` (info). |
+
+---
+
+## Usage
+
+```csharp
+using BitcoinKernel;
+
+using var logging = new LoggingConnection((category, message, level) =>
+{
+    Console.WriteLine($"[{level}] {category}: {message}");
+});
+
+// Keep the object alive while kernel operations run.
+```
+
+---
+
+## Notes
+
+- Dispose `LoggingConnection` when logging is no longer needed.
+- Callback lifetime is pinned internally so it remains valid for native calls.
+- Current implementation includes TODO behavior for parsing exact native category/level from raw message text.

--- a/docs/dotnet-api/script-verification.md
+++ b/docs/dotnet-api/script-verification.md
@@ -1,0 +1,91 @@
+---
+title: ScriptVerification
+---
+
+# `ScriptVerification`
+
+`BitcoinKernel.ScriptVerification`
+
+Script verification helpers and precomputed transaction data.
+
+---
+
+## PrecomputedTransactionData
+
+```csharp
+public sealed class PrecomputedTransactionData : IDisposable
+{
+    public PrecomputedTransactionData(
+        Transaction transaction,
+        IReadOnlyList<TxOut>? spentOutputs = null);
+
+    public void Dispose();
+}
+```
+
+Precomputes script data for repeated verification on the same transaction.
+
+Use `spentOutputs` when Taproot verification is required.
+
+---
+
+## ScriptVerifier
+
+```csharp
+public static class ScriptVerifier
+{
+    public static bool VerifyScript(
+        ScriptPubKey scriptPubkey,
+        long amount,
+        Transaction transaction,
+        PrecomputedTransactionData? precomputedTxData,
+        uint inputIndex,
+        ScriptVerificationFlags flags = ScriptVerificationFlags.All);
+
+    public static bool VerifyScript(
+        ScriptPubKey scriptPubkey,
+        long amount,
+        Transaction transaction,
+        uint inputIndex,
+        List<TxOut> spentOutputs,
+        ScriptVerificationFlags flags = ScriptVerificationFlags.All);
+}
+```
+
+Both overloads throw `ScriptVerificationException` if verification status is not `OK`.
+
+| Parameter | Description |
+|:----------|:------------|
+| `scriptPubkey` | Locking script being evaluated. |
+| `amount` | Amount in satoshis for spent output. |
+| `transaction` | Spending transaction containing the input. |
+| `inputIndex` | Input index inside `transaction`. |
+| `flags` | Bitmask of `ScriptVerificationFlags`. |
+
+Overload-specific behavior:
+
+- `precomputedTxData` overload: best when precomputed data is reused across input checks.
+- `List<TxOut>` overload: creates/destroys precomputed data internally.
+
+---
+
+## Example
+
+```csharp
+using BitcoinKernel.Primatives;
+using BitcoinKernel.ScriptVerification;
+using BitcoinKernel.Interop.Enums;
+
+using var script = ScriptPubKey.FromHex("0014...");
+using var tx = Transaction.FromHex("0200...");
+
+var ok = ScriptVerifier.VerifyScript(
+    scriptPubkey: script,
+    amount: 1000,
+    transaction: tx,
+    precomputedTxData: null,
+    inputIndex: 0,
+    flags: ScriptVerificationFlags.AllPreTaproot);
+
+Console.WriteLine($"Verified: {ok}");
+```

--- a/docs/dotnet-api/transactions.md
+++ b/docs/dotnet-api/transactions.md
@@ -1,0 +1,125 @@
+---
+title: Transactions
+---
+
+# `Transactions`
+
+`BitcoinKernel.Primatives`
+
+Transaction-level primitives: transactions, outputs, scripts, coins, and spent-output collections.
+
+---
+
+## Transaction
+
+```csharp
+public sealed class Transaction : IDisposable
+{
+    public Transaction(byte[] rawTransaction);
+    public Transaction(string hexString);
+
+    public static Transaction FromBytes(byte[] rawTransaction);
+    public static Transaction FromHex(string hexString);
+
+    public int InputCount { get; }
+    public int OutputCount { get; }
+
+    public byte[] GetTxid();
+    public string GetTxidHex();
+
+    public IntPtr GetInputAt(int index);
+    public TxOut GetOutputAt(int index);
+
+    public Transaction Copy();
+    public void Dispose();
+}
+```
+
+| Method | Description |
+|:-------|:------------|
+| `GetInputAt(int)` | Returns a non-owning native input pointer for low-level interop use. Pointer lifetime is tied to the parent `Transaction`. |
+| `GetOutputAt(int)` | Returns output wrapper at index. |
+| `Copy()` | Duplicates the transaction. |
+
+---
+
+## ScriptPubKey
+
+```csharp
+public sealed class ScriptPubKey : IDisposable
+{
+    public static ScriptPubKey FromBytes(byte[] scriptBytes);
+    public static ScriptPubKey FromHex(string hexString);
+    public void Dispose();
+}
+```
+
+Locking-script wrapper used by `TxOut` and script verification APIs.
+
+---
+
+## TxOut
+
+```csharp
+public class TxOut : IDisposable
+{
+    public TxOut(ScriptPubKey scriptPubKey, long amount);
+
+    public static TxOut Create(IntPtr scriptPubkeyPtr, long amount);
+    public static TxOut Create(ScriptPubKey scriptPubKey, long amount);
+
+    public long Amount { get; }
+    public IntPtr GetScriptPubkeyPtr();
+    public byte[] GetScriptPubkey();
+
+    public TxOut Copy();
+    public void Dispose();
+}
+```
+
+Represents a single transaction output (amount + script).
+
+---
+
+## Coin
+
+```csharp
+public class Coin : IDisposable
+{
+    public uint ConfirmationHeight { get; }
+    public bool IsCoinbase { get; }
+
+    public TxOut GetOutput();
+    public Coin Copy();
+
+    public void Dispose();
+}
+```
+
+Represents a spendable output and metadata.
+
+`GetOutput()` returns a non-owning view tied to the `Coin` lifetime.
+
+---
+
+## TransactionSpentOutputs
+
+```csharp
+public class TransactionSpentOutputs : IDisposable
+{
+    public int Count { get; }
+    public Coin GetCoin(int index);
+    public IEnumerable<Coin> EnumerateCoins();
+    public void Dispose();
+}
+```
+
+Collection of spent coins for one non-coinbase transaction.
+
+---
+
+## Ownership Notes
+
+- Several accessors return non-owning views/pointers (`GetInputAt`, `GetOutputAt`, `GetOutput`, spent-output traversal objects).
+- Keep parent objects alive while using child views.
+- Prefer `Copy()` when you need an independent owned object.

--- a/zensical.toml
+++ b/zensical.toml
@@ -31,7 +31,16 @@ nav = [
   { "Go Bindings"     = [{ "Overview" = "go-api/index.md" }] },
   { "Rust Bindings"   = [{ "Overview" = "rust-api/index.md" }] },
   { "Python Bindings" = [{ "Overview" = "python-api/index.md" }] },
-  { ".NET Bindings"   = [{ "Overview" = "dotnet-api/index.md" }] },
+  { ".NET Bindings"   = [
+    { "Overview"      = "dotnet-api/index.md" },
+    { "KernelTypes"   = "dotnet-api/kernel-types.md" },
+    { "Context"       = "dotnet-api/context.md" },
+    { "Chainstate"    = "dotnet-api/chainstate.md" },
+    { "Blocks"        = "dotnet-api/blocks.md" },
+    { "Transactions"  = "dotnet-api/transactions.md" },
+    { "ScriptVerification" = "dotnet-api/script-verification.md" },
+    { "Logger"        = "dotnet-api/logger.md" },
+  ] },
 ]
 
 [project.theme]


### PR DESCRIPTION
This PR adds the initial .NET API documentation for BitcoinKernel.NET project. The documents are  compatible with version of BitcoinKernel.NET 0.2.0.

A complete set of reference page and an updated version of the sites navigation is introduced 